### PR TITLE
Support schema directive validation on input arguments

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,8 +19,9 @@
   <properties>
     <java.version>11</java.version>
     <pmd.version>3.11.0</pmd.version>
-    <graphql.version>7.1.0</graphql.version>
-    <graphql.extended.scalaras.version>1.0.1</graphql.extended.scalaras.version>
+    <graphql.version>8.0.0</graphql.version>
+    <graphql.extended.scalars.version>1.0.1</graphql.extended.scalars.version>
+    <graphql.extended.validation.version>15.0.1</graphql.extended.validation.version>
   </properties>
 
   <dependencies>
@@ -32,7 +33,7 @@
     <dependency>
       <groupId>com.graphql-java</groupId>
       <artifactId>graphql-java-extended-scalars</artifactId>
-      <version>${graphql.extended.scalaras.version}</version>
+      <version>${graphql.extended.scalars.version}</version>
       <exclusions>
         <exclusion>
           <groupId>com.graphql-java</groupId>
@@ -43,6 +44,15 @@
     <dependency>
       <groupId>org.hibernate.validator</groupId>
       <artifactId>hibernate-validator</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-security</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.graphql-java</groupId>
+      <artifactId>graphql-java-extended-validation</artifactId>
+      <version>${graphql.extended.validation.version}</version>
     </dependency>
     <dependency>
       <groupId>org.projectlombok</groupId>
@@ -60,10 +70,6 @@
       <artifactId>voyager-spring-boot-starter</artifactId>
       <version>${graphql.version}</version>
       <scope>runtime</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-security</artifactId>
     </dependency>
     <dependency>
       <groupId>com.graphql-java-kickstart</groupId>

--- a/src/main/java/com/learn/graphql/config/ValidationDirectiveConfig.java
+++ b/src/main/java/com/learn/graphql/config/ValidationDirectiveConfig.java
@@ -1,0 +1,26 @@
+package com.learn.graphql.config;
+
+import graphql.validation.rules.OnValidationErrorStrategy;
+import graphql.validation.rules.ValidationRules;
+import graphql.validation.schemawiring.ValidationSchemaWiring;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Chapter 32: Schema Directive Validation
+ */
+@Configuration
+public class ValidationDirectiveConfig {
+
+  @Bean
+  public ValidationSchemaWiring validationSchemaWiring() {
+    // This contains by default the standard library provided @Directive constraints
+    var validationRules = ValidationRules.newValidationRules()
+        .onValidationErrorStrategy(OnValidationErrorStrategy.RETURN_NULL)
+        .build();
+
+    // This will rewrite your data fetchers when rules apply to them so that validation
+    return new ValidationSchemaWiring(validationRules);
+  }
+
+}

--- a/src/main/java/com/learn/graphql/config/ValidationDirectiveConfig.java
+++ b/src/main/java/com/learn/graphql/config/ValidationDirectiveConfig.java
@@ -14,12 +14,12 @@ public class ValidationDirectiveConfig {
 
   @Bean
   public ValidationSchemaWiring validationSchemaWiring() {
-    // This contains by default the standard library provided @Directive constraints
+    // Contains the default validation @Directive constraints
     var validationRules = ValidationRules.newValidationRules()
         .onValidationErrorStrategy(OnValidationErrorStrategy.RETURN_NULL)
         .build();
 
-    // This will rewrite your data fetchers when rules apply to them so that validation
+    // Rewrites your data fetchers so that it's arguments are validated prior method execution
     return new ValidationSchemaWiring(validationRules);
   }
 

--- a/src/main/java/com/learn/graphql/resolver/bank/mutation/BankAccountMutation.java
+++ b/src/main/java/com/learn/graphql/resolver/bank/mutation/BankAccountMutation.java
@@ -15,16 +15,34 @@ import org.springframework.stereotype.Component;
 import org.springframework.validation.annotation.Validated;
 
 @Slf4j
+@Validated
 @Component
 @RequiredArgsConstructor
-@Validated
 public class BankAccountMutation implements GraphQLMutationResolver {
 
   private final Clock clock;
 
+  /**
+   * JSR-303 Bean Validation (Chapter 18)
+   */
   public BankAccount createBankAccount(@Valid CreateBankAccountInput input) {
     log.info("Creating bank account for {}", input);
-    return BankAccount.builder().id(UUID.randomUUID()).currency(Currency.USD)
+    return BankAccount.builder()
+        .id(UUID.randomUUID())
+        .currency(Currency.USD)
+        .createdAt(ZonedDateTime.now(clock))
+        .createdOn(LocalDate.now(clock))
+        .build();
+  }
+
+  /**
+   * Schema Directive Validation (Chapter 32)
+   */
+  public BankAccount updateBankAccount(UUID id, String name, int age) {
+    log.info("Updating bank account for {}. Name: {}, age: {}", id, name, age);
+    return BankAccount.builder()
+        .id(UUID.randomUUID())
+        .currency(Currency.USD)
         .createdAt(ZonedDateTime.now(clock))
         .createdOn(LocalDate.now(clock))
         .build();

--- a/src/main/resources/ValidationMessages.properties
+++ b/src/main/resources/ValidationMessages.properties
@@ -1,0 +1,2 @@
+updateBankAccount.name=${gqlArgument.name} must not be blank.
+updateBankAccount.age=${gqlArgument.name} ({validatedValue}) must be less than 500.

--- a/src/main/resources/graphql/mutation.graphqls
+++ b/src/main/resources/graphql/mutation.graphqls
@@ -6,6 +6,8 @@ scalar Date
 type Mutation {
     # Create a bank account
     createBankAccount(input: CreateBankAccountInput!): BankAccount!
+    # Update a bank account
+    updateBankAccount(id: ID, name: String! @NotBlank(message: "updateBankAccount.name"), age: Int @Expression(value: "${validatedValue < 500}" message: "updateBankAccount.age")): BankAccount!
     # Upload a file
     uploadFile: ID!
 }

--- a/src/main/resources/playground/bank_account.graphql
+++ b/src/main/resources/playground/bank_account.graphql
@@ -1,4 +1,4 @@
-# Gets Philip's Bank account
+# Gets bank account
 query GET_BANK_ACCOUNT($id: ID) {
     bankAccount(id: $id) {
         currency
@@ -7,5 +7,19 @@ query GET_BANK_ACCOUNT($id: ID) {
             firstName
             lastName
         }
+    }
+}
+
+# Create bank account
+mutation CREATE_BANK_ACCOUNT {
+    createBankAccount(input: { firstName: "" age: 50 }) {
+        id
+    }
+}
+
+# Update bank account
+mutation UPDATE_BANK_ACCOUNT($id: ID) {
+    updateBankAccount(id: $id name: "philip", age: 500) {
+        id
     }
 }


### PR DESCRIPTION
- Support for @Directive validation on input arguments
- Custom error messages supplied via `ValidationMessages.properties`
- GraphQL Major bump to 8.*

Note: Validation @Directives on nested input types are not triggered.